### PR TITLE
Atualizações Técnicas

### DIFF
--- a/src/main/java/com/bernardo/Beer.java
+++ b/src/main/java/com/bernardo/Beer.java
@@ -1,10 +1,12 @@
 package com.bernardo;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.ItemFlag;
@@ -12,20 +14,25 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-public final class beer extends JavaPlugin implements Listener {
+import javax.xml.stream.events.Namespace;
+
+public final class Beer extends JavaPlugin implements Listener {
+    private NamespacedKey CUSTOM_ITEMS_KEY;
+    private final String beerItemId = "beer_potion";
 
     @Override
     public void onEnable() {
         getLogger().info("BeerPlugin has been enabled.");
         getServer().getPluginManager().registerEvents(this, this);
-
-        ItemStack beer = createBeerItem();
-        NamespacedKey beerKey = new NamespacedKey(this, "beer_recipe");
-        ShapelessRecipe beerRecipe = new ShapelessRecipe(beerKey, beer);
+        this.CUSTOM_ITEMS_KEY = new NamespacedKey(this, "com.bernado.items");
+        NamespacedKey beerKey = new NamespacedKey(this, "com.bernado.recipes.beer");
+        ShapelessRecipe beerRecipe = new ShapelessRecipe(beerKey, createBeerItem());
         beerRecipe.addIngredient(Material.POTION);
         beerRecipe.addIngredient(Material.WHEAT);
         beerRecipe.addIngredient(Material.FERMENTED_SPIDER_EYE);
@@ -34,14 +41,15 @@ public final class beer extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
         getLogger().info("BeerPlugin has been disabled.");
+        HandlerList.unregisterAll();
     }
 
     @EventHandler
     public void onPlayerDrink(PlayerItemConsumeEvent event) {
+        Player player = event.getPlayer();
         ItemStack item = event.getItem();
-        if (item.getType() == Material.POTION && item.getItemMeta().hasDisplayName() &&
-                item.getItemMeta().getDisplayName().equals("Beer")) {
-            Player player = event.getPlayer();
+        PersistentDataContainer pdc = item.getItemMeta().getPersistentDataContainer();
+        if (pdc.has(CUSTOM_ITEMS_KEY, PersistentDataType.STRING) && pdc.get(CUSTOM_ITEMS_KEY, PersistentDataType.STRING).equals(beerItemId)) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 14 * 20, 2));
             player.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 14 * 20, 0));
             player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 10 * 20, 0));
@@ -55,7 +63,8 @@ public final class beer extends JavaPlugin implements Listener {
         potionMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
         beer.setItemMeta(potionMeta);
         ItemMeta meta = beer.getItemMeta();
-        meta.setDisplayName("Beer");
+        meta.getPersistentDataContainer().set(CUSTOM_ITEMS_KEY, PersistentDataType.STRING, beerItemId);
+        meta.displayName(Component.text("Beer"));
         beer.setItemMeta(meta);
         return beer;
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,8 @@
 name: Beer
+description: Um plugin que adiciona Cerveja ao jogo.
+authors:
+  - Bernado
+  - Jhefferson
 version: '${project.version}'
 main: com.bernardo.beer
 api-version: '1.20'


### PR DESCRIPTION
Agora o item "Beer" possui um ID em seu PersistentDataContainer.
A verificação de consumo de uma "Beer" vê se o item consumido tem o ID registrado no PersistentDataContainer para evitar falsificações (Pegar uma poção qualquer, renomear para "Beer" faria o sistema contar como cerveja).
Alterações na plugin.yml: Adicionado autores e uma descrição ao plugin.